### PR TITLE
Update notification hooks to use terminal-notifier

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -1,12 +1,23 @@
 {
   "hooks": {
+    "Notification": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "terminal-notifier -title 'Claude Code' -message 'Awaiting your input' -sound Sosumi"
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "matcher": "*",
         "hooks": [
           {
             "type": "command",
-            "command": "afplay /System/Library/Sounds/Glass.aiff"
+            "command": "terminal-notifier -title 'Claude Code' -message '✨ Task Complete' -sound Glass"
           }
         ]
       }


### PR DESCRIPTION
## Summary
- Add notification hook to alert when awaiting user input
- Update stop hook to use terminal-notifier instead of afplay for better notification management
- Improve notification messages with emojis and clearer text

## Changes Made
- Added new "Notification" hook that triggers on all events to show when Claude is awaiting input
- Updated existing "Stop" hook to use terminal-notifier with enhanced messaging
- Changed notification sound and message format for better user experience

## Test Plan
- [x] Verify notification hooks are properly formatted in settings.json
- [x] Test that notifications appear when Claude is awaiting input
- [x] Test that completion notifications work with new terminal-notifier command
- [x] Confirm sounds play correctly (Sosumi for awaiting input, Glass for completion)

🤖 Generated with [Claude Code](https://claude.ai/code)