### PR TITLE
Add README with terminal-notifier setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,35 @@
+# Claude Code Configuration
+
+This repository contains Claude Code configuration files and settings.
+
+## Prerequisites
+
+### Install terminal-notifier
+
+The notification hooks in `settings.json` require `terminal-notifier` for macOS notifications. Install it using Homebrew:
+
+```bash
+brew install terminal-notifier
+```
+
+### Verify Installation
+
+Test that terminal-notifier is working:
+
+```bash
+terminal-notifier -title 'Test' -message 'Installation successful!' -sound Glass
+```
+
+## Configuration
+
+- `settings.json` - Contains hooks for notifications during Claude Code sessions
+- `CLAUDE.local.md` - Personal preferences and local instructions
+
+## Notification Hooks
+
+The configuration includes two notification hooks:
+
+1. **Notification Hook** - Alerts when Claude is awaiting input (Sosumi sound)
+2. **Stop Hook** - Confirms when tasks are complete (Glass sound)
+
+These hooks enhance the Claude Code experience by providing audio and visual feedback during long-running tasks.


### PR DESCRIPTION
## Summary
- Add comprehensive README.md documentation for the Claude Code configuration
- Include step-by-step terminal-notifier installation instructions using Homebrew
- Document all configuration files and their purposes
- Explain notification hooks functionality and sounds

## Changes Made
- Created README.md with clear setup instructions
- Added verification steps for testing terminal-notifier installation
- Documented the notification hook system (Notification and Stop hooks)
- Provided overview of configuration structure

## Why This Change?
The notification hooks in settings.json require terminal-notifier to function properly. This README ensures users can easily set up their environment and understand how the notification system works.

## Test Plan
- [x] README.md is properly formatted and readable
- [x] Verify terminal-notifier installation instructions work on clean macOS system
- [x] Test that verification command produces expected notification
- [ ] Confirm all documented files and hooks are accurate

🤖 Generated with [Claude Code](https://claude.ai/code)